### PR TITLE
Adding manifests for QA workload testing.

### DIFF
--- a/manifests/workloads/cisnodeport.yaml
+++ b/manifests/workloads/cisnodeport.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pstools-nodeport-deployment
+spec:
+  selector:
+    matchLabels:
+      app: pstools-app-node
+  replicas: 4
+  template:
+    metadata:
+      labels:
+        app: pstools-app-node
+    spec:
+      containers:
+        - name: pstools
+          image: phillipsj/pstools:v0.2.0
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: pstools-app-node
+  name: pstools-nodeport-svc
+  namespace: default
+spec:
+  type: NodePort
+  ports:
+    - port: 3000
+      nodePort: 30096
+      name: http
+  selector:
+    app: pstools-app-node

--- a/manifests/workloads/daemonset.yaml
+++ b/manifests/workloads/daemonset.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: mixed-os-othertest-deploy
+  labels:
+    app: mixed-os-othertest
+spec:
+  selector:
+    matchLabels:
+      app: mixed-os-othertest
+  template:
+    metadata:
+      labels:
+        app: mixed-os-othertest
+    spec:
+      containers:
+        - name: mixed-os-othertest
+          image: phillipsj/pstools:v0.2.0
+          imagePullPolicy: Always

--- a/manifests/workloads/ingress.yaml
+++ b/manifests/workloads/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mixed-os-othertest-ingress-svc
+  labels:
+    app: mixed-os-othertest
+spec:
+  ports:
+    - port: 8080
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app: mixed-os-othertest
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mixed-os-othertest-ingress
+spec:
+  rules:
+    - host: test1.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: mixed-os-othertest-ingress-svc
+                port:
+                  number: 8080
+            pathType: ImplementationSpecific

--- a/manifests/workloads/pwsh.yaml
+++ b/manifests/workloads/pwsh.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pwsh
+spec:
+  selector:
+    app: pwsh
+  clusterIP: None
+  ports:
+    - name: foo # Actually, no port is needed.
+      port: 1234
+      targetPort: 1234
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pwshdep
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: pwsh
+  template:
+    metadata:
+      labels:
+        app: pwsh
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - windows
+      containers:
+        - name: pwsh
+          image: mcr.microsoft.com/powershell:nanoserver
+          command:
+            - "pwsh.exe"
+            - "-Command"
+            - "sleep 3600"


### PR DESCRIPTION
This adds equivalent windows manifests for workloads that are already being tested as part of QA.

* https://github.com/rancher/windows/issues/143

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>