### PR TITLE
[Draft] Parameterize managed-ad-server users

### DIFF
--- a/terraform/aws/managed-ad-server/README.md
+++ b/terraform/aws/managed-ad-server/README.md
@@ -79,4 +79,6 @@ Useful Content:
 
 https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_directory
 
+https://registry.terraform.io/providers/hashicorp/ad/latest/docs
+
 https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_key_concepts_gmsa.html

--- a/terraform/aws/managed-ad-server/default.auto.tfvars.example
+++ b/terraform/aws/managed-ad-server/default.auto.tfvars.example
@@ -8,3 +8,53 @@ windows_admin_password  = "" # the password for the `rancher` administrator user
 prefix                  = "" # name to prefix certain AWS resources with
 ad_group_name           = "test group" # Base name for AD Groups
 ad_sam_name             = "TESTGROUP" # Base name for SAM Accounts
+ad_name                 = "" # the name of the manged active directory instance
+
+# active_directory_users specifies
+# a list of users who should be added
+# to the active directory. They must
+# specify a pre-defined organizational unit (OU).
+# If a user is within the TestOU, a group must also
+# be assigned.
+#
+# Available OU's: TestOU, gplinktestOU
+# For more information on Organizational Units,
+# see: https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc759186(v=ws.10)#active-directory-domains-and-forests-1
+#
+# Available Groups: domainlocal, global, universal
+# For more information on the available groups,
+# see: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-groups#group-scope
+active_directory_users = [
+      {
+      display_name = "test user 1"
+      principal_name = "tu1"
+      sam_account_name = "tu1"
+      initial_password = "password123"
+      group = "domainlocal"
+      organizational_unit = "gplinktestOU"
+    },
+    {
+      display_name = "test user 2"
+      principal_name = "tu1"
+      sam_account_name = "tu1"
+      initial_password = "password123"
+      group = "domainlocal"
+      organizational_unit = "gplinktestOU"
+    },
+    {
+      display_name = "test user 3"
+      principal_name = "tu1"
+      sam_account_name = "tu1"
+      initial_password = "password123"
+      group = "domainlocal"
+      organizational_unit = "gplinktestOU"
+    },
+    {
+      display_name = "test user 4"
+      principal_name = "tu1"
+      sam_account_name = "tu1"
+      initial_password = "password123"
+      group = ""
+      organizational_unit = "TestOU"
+    }
+  ]

--- a/terraform/aws/managed-ad-server/modules/populate-ad/populate.tf
+++ b/terraform/aws/managed-ad-server/modules/populate-ad/populate.tf
@@ -1,4 +1,9 @@
 # create OU for testing
+
+# OU 'o' will have three active directory groups
+# attached to it, 'domainlocal', 'global', and 'universal'.
+# it will also have a group policy object and group policy object link
+# added to it.
 resource "ad_ou" "o" {
   name        = "TestOU"
   path        = var.path
@@ -6,6 +11,8 @@ resource "ad_ou" "o" {
   protected   = false
 }
 
+# OU 'o2' will have a group policy object and group policy object link
+# added to it.
 resource "ad_ou" "o2" {
   name        = "gplinktestOU"
   path        = var.path
@@ -13,31 +20,19 @@ resource "ad_ou" "o2" {
   protected   = false
 }
 
-# create users
-resource ad_user "user1" {
-    display_name     = "Terraform Test User1"
-    principal_name   = "testUser1"
-    sam_account_name = "testUser1"
-    initial_password = "Rancher123!!@@"
+resource "ad_user" "all_users" {
+  for_each = {for user in var.active_directory_users: user.display_name => user}
+
+  display_name     = each.value.display_name
+  principal_name   = each.value.principal_name
+  sam_account_name = each.value.sam_account_name
+  initial_password = each.value.initial_password
+
+  container = each.value.organizational_unit == "TestOU" ? ad_ou.o.dn : ad_ou.o2.dn
 }
 
-resource ad_user "user2" {
-    display_name     = "Terraform Test User2"
-    principal_name   = "testUser2"
-    sam_account_name = "testUser2"
-    initial_password = "Rancher123!!@@"
-    container        = ad_ou.o.dn
-}
-
-resource ad_user "user3" {
-    display_name     = "Terraform Test User3"
-    principal_name   = "testUser3"
-    sam_account_name = "testUser3"
-    initial_password = "Rancher123!!@@"
-    container        = ad_ou.o2.dn
-}
-
-# create groups
+# create 3 static groups within the TestOU, each with
+# a different scope so that all scopes can be tested.
 resource "ad_group" "global" {
   name             = var.ad_group_name
   sam_account_name = var.ad_sam_name
@@ -62,20 +57,21 @@ resource ad_group "universal" {
     category         = "security"
 }
 
-# create group memberships
+# create assign users to particular group memberships
+# based off of the users 'group' attribute
 resource ad_group_membership "gm1" {
     group_id = ad_group.global.id
-    group_members  = [ ad_group.global.id, ad_user.user1.id, ad_user.user2.id ]
+    group_members  = concat(local.gm1_users[0], [ad_group.global.id])
 }
 
 resource ad_group_membership "gm2" {
     group_id = ad_group.domainlocal.id
-    group_members  = [ ad_group.domainlocal.id, ad_user.user1.id, ad_user.user2.id ]
+    group_members = concat(local.gm2_users[0], [ad_group.domainlocal.id])
 }
 
 resource ad_group_membership "gm3" {
     group_id = ad_group.universal.id
-    group_members  = [ ad_group.universal.id, ad_user.user1.id, ad_user.user2.id ]
+    group_members  = concat(local.gm3_users[0], [ad_group.universal.id])
 }
 
 # create gpo object
@@ -93,7 +89,6 @@ resource "ad_gpo" "gpo2" {
   status      = "AllSettingsEnabled"
 }
 
-
 # create gplink
 resource "ad_gplink" "link1" {
   gpo_guid  = ad_gpo.gpo1.id
@@ -108,4 +103,18 @@ resource "ad_gplink" "link2" {
   target_dn = ad_ou.o2.dn
   enforced  = true
   enabled   = true
+}
+
+locals {
+  gm1_users = tolist([for each in var.active_directory_users : [
+     for eachuser in ad_user.all_users: eachuser.id if each.group == "global"
+    ]])
+
+  gm2_users = tolist([for each in var.active_directory_users : [
+     for eachuser in ad_user.all_users: eachuser.id if each.group == "universal"
+  ]])
+
+  gm3_users = tolist([for each in var.active_directory_users : [
+    for eachuser in ad_user.all_users: eachuser.id if each.group == "domainlocal"
+  ]])
 }

--- a/terraform/aws/managed-ad-server/modules/populate-ad/variables.tf
+++ b/terraform/aws/managed-ad-server/modules/populate-ad/variables.tf
@@ -17,3 +17,15 @@ variable "ad_sam_name" {
     type = string 
     description = "Base name for SAM Accounts"
 }
+
+variable "active_directory_users" {
+  type = list(object({
+    organizational_unit = string
+    display_name = string
+    principal_name = string
+    sam_account_name = string
+    initial_password = string
+    # e.g. global, domainlocal, universal
+    group = string
+  }))
+}

--- a/terraform/aws/managed-ad-server/outputs.tf
+++ b/terraform/aws/managed-ad-server/outputs.tf
@@ -11,7 +11,7 @@ output "ad_bastion_public_ip" {
 }
 
 output "windows_bastion_password" {
-    value = data.template_file.decrypted_keys[0].rendered
+    value = rsadecrypt(aws_instance.windows[0].password_data, tls_private_key.ssh_key.private_key_pem)
 }
 
 output "aws_managed_ad_url" {
@@ -32,6 +32,7 @@ output "aws_managed_ad_short_name" {
 output "aws_managed_ad_password" {
     description = "Administrator password for managing the new AWS Directory Service Managed Active Directory Server"
     value = random_password.this.result
+    sensitive = true
 }
 
 output "aws_managed_ad_dns" {

--- a/terraform/aws/managed-ad-server/variables.tf
+++ b/terraform/aws/managed-ad-server/variables.tf
@@ -43,3 +43,20 @@ variable "ad_sam_name" {
     type = string 
     description = "Base name for SAM Accounts"
 }
+
+variable "active_directory_users" {
+  type = list(object({
+    organizational_unit = string
+    display_name = string
+    principal_name = string
+    sam_account_name = string
+    initial_password = string
+    # e.g. global, domainlocal, universal
+    group = string
+  }))
+}
+
+variable "ad_name" {
+  type = string
+  description = "name of the active directory aws instance"
+}


### PR DESCRIPTION
Changes
+ Updates the schema for the aws managed-ad-server module such that many users may be defined up front as variables.  Aspects such as the OU and group the users are apart of are no longer hard coded
+ Adds additional documentation to the README.md to provide links to the `ad` provider documentation
+ Removes a use of `template_file`, which is deprecated and does not work on Apple M1 systems.
    + This change still needs to be tested


At the moment, this PR does _not_ parameterize the creation of OU's, Groups, Group Policy Objects, or Group Policy Object Links. I think having static definitions for these aspects of the AD are fine for now, and we can parameterize them if we find a need to in the future. 

This PR is in a draft state until it can be properly tested, currently new AWS permissions are required to actually create the active directory service in a particular VPC. I've requested these permissions and will update this PR with test results in the future. 