### PR TITLE
Add new example tfvars file, update README.md, small grammar changes

### DIFF
--- a/terraform/azure_rke2_cluster/examples/all_supported_versions.tfvars
+++ b/terraform/azure_rke2_cluster/examples/all_supported_versions.tfvars
@@ -1,0 +1,32 @@
+nodes = [
+  {
+    name     = "linux-server"
+    image    = "linux"
+    roles    = ["etcd", "controlplane", "worker"]
+    replicas = 1
+  },
+  {
+    name     = "windows-2022-core-worker"
+    image    = "windows-2022-core"
+    roles    = ["worker"]
+    replicas = 1
+  },
+  {
+    name     = "windows-2019-core-worker"
+    image    = "windows-2019-core"
+    roles    = ["worker"]
+    replicas = 1
+  },
+  {
+    name     = "windows-2022-worker"
+    image    = "windows-2022"
+    roles    = ["worker"]
+    replicas = 1
+  },
+  {
+    name     = "windows-2019-worker"
+    image    = "windows-2019"
+    roles    = ["worker"]
+    replicas = 1
+  }
+]

--- a/terraform/azure_server/README.md
+++ b/terraform/azure_server/README.md
@@ -15,12 +15,12 @@ terraform -chdir=terraform/azure_server init
 
 # Change the following variable to the cluster name you desire
 # Note: It's recommended that you should use your own name instead of "clippy" so that you can identify the resources you create in your cloud provider, should the Terraform module fail for some reason and require manual cleanup of resources.
-export TF_VAR_name="clippy-test"
+export TF_VAR_name="clippy-test-server"
 
 terraform -chdir=terraform/azure_server apply
 ```
 
-This command should prompt you to provide the Rancher name and will spin up a **Azure server**.
+This command should prompt you to provide the Rancher name and will spin up an **Azure server**.
 
 Once it has finished running, you can run the following command to get the relevant commands you need to get onto the host if you need to debug any problems (the `terraform apply` operation will output this):
 
@@ -51,6 +51,22 @@ terraform -chdir=terraform/azure_server output
 
 terraform -chdir=terraform/azure_server destroy -var-file="examples/windows.tfvars"
 ```
+
+## Creating a Windows node with the Containers feature enabled
+
+Windows Servers do not come configured with support for containerized workloads out of the box; in order for a Windows Server to run containerized workloads, you must install the optional `Containers` feature.
+
+To trigger the module to create a Windows node with the `Containers` feature enabled, use the example from [`examples/windows_containers.tfvars`](./examples/windows_containers.tfvars)
+
+```bash
+terraform -chdir=terraform/azure_server apply -var-file="examples/windows_containers.tfvars"
+
+terraform -chdir=terraform/azure_server output
+
+terraform -chdir=terraform/azure_server destroy -var-file="examples/windows_containers.tfvars"
+```
+
+> **Note:** The node will be automatically restarted once the Containers feature installs, due to this you should wait about 1-2 minutes after provisioning to register the node.
 
 ## State of Support
 

--- a/terraform/azure_server/examples/windows_2022_containers.tfvars
+++ b/terraform/azure_server/examples/windows_2022_containers.tfvars
@@ -1,0 +1,7 @@
+image = "windows-2022-core"
+scripts = [
+  <<-EOT
+    Enable-WindowsOptionalFeature -Online -FeatureName containers -All -NoRestart;
+    Start-Process -NoNewWindow powershell.exe "Start-Sleep 3; Restart-Computer -Confirm:`$false;";
+    EOT
+]


### PR DESCRIPTION
+ Update the `azure_server` module's README.md to include a section on creating windows servers with the `Containers` feature enabled.

+ Add an example for using Windows 2022, since the existing example just specifies an image of `windows`, which can be confusing when trying to use a specific version of Windows server. 

+ Update example use of `TF_VAR_name` to include the required postfix of `-server` 