### PR TITLE
Use Windows server instead of server core by default

### DIFF
--- a/terraform/azure_server/examples/windows_2022_containers.tfvars
+++ b/terraform/azure_server/examples/windows_2022_containers.tfvars
@@ -1,4 +1,4 @@
-image = "windows-2022-core"
+image = "windows-2022"
 scripts = [
   <<-EOT
     Enable-WindowsOptionalFeature -Online -FeatureName containers -All -NoRestart;

--- a/terraform/azure_server/examples/windows_containers.tfvars
+++ b/terraform/azure_server/examples/windows_containers.tfvars
@@ -1,4 +1,4 @@
-image = "windows"
+image = "windows-2019"
 scripts = [
   <<-EOT
     Enable-WindowsOptionalFeature -Online -FeatureName containers -All -NoRestart;


### PR DESCRIPTION
For debugging purposes its useful to use a standard Windows server instance as opposed to Windows server core, since debugging using the GUI is much easier than handling various PowerShell scripts. This PR changes the default when creating `azure_server` instances using the provided examples. 