### PR TITLE
Fix default K8s version for RKE2_cluster

### DIFF
--- a/terraform/azure_rke2_cluster/variables.tf
+++ b/terraform/azure_rke2_cluster/variables.tf
@@ -6,7 +6,7 @@ variable "name" {
 variable "kubernetes_version" {
   type        = string
   description = "The version of RKE2 that you would like to use to provision a cluster."
-  default     = "v1.24.13+rke2r1"
+  default     = "v1.24.17+rke2r1"
 }
 
 variable "active_directory" {


### PR DESCRIPTION
RKE v1.24.13 doesn't use containerd 1.7, which is a requirement for the account provider. This PR just bumps that version to the latest version of 1.24, 1.24.17