### PR TITLE
Add various fixes for gMSA CCG Terraform

### DIFF
--- a/terraform/azure_docker_rancher/examples/head.tfvars
+++ b/terraform/azure_docker_rancher/examples/head.tfvars
@@ -1,0 +1,1 @@
+rancher_version = "2.8-head"

--- a/terraform/azure_docker_rancher/main.tf
+++ b/terraform/azure_docker_rancher/main.tf
@@ -74,6 +74,7 @@ module "server" {
     {
       name  = var.name
       image = module.images.source_images["linux"]
+      size  = var.size
       scripts = [
         templatefile("${path.module}/files/install_docker.sh", {
           docker_version = var.docker_version

--- a/terraform/azure_docker_rancher/variables.tf
+++ b/terraform/azure_docker_rancher/variables.tf
@@ -8,10 +8,16 @@ variable "name" {
   }
 }
 
+variable "size" {
+  type        = string
+  description = "Default size to use for the single server this Rancher instance will run on."
+  default     = "Standard_B4als_v2"
+}
+
 variable "rancher_version" {
   type        = string
   description = "Version of Rancher to use. Find this on https://hub.docker.com/r/rancher/rancher."
-  default     = "2.7.3"
+  default     = "2.7.7"
 }
 
 variable "create_record" {

--- a/terraform/azure_rke2_cluster/examples/all_supported_versions.tfvars
+++ b/terraform/azure_rke2_cluster/examples/all_supported_versions.tfvars
@@ -2,6 +2,7 @@ nodes = [
   {
     name     = "linux-server"
     image    = "linux"
+    size     = "Standard_B4als_v2"
     roles    = ["etcd", "controlplane", "worker"]
     replicas = 1
   },

--- a/terraform/azure_rke2_cluster/examples/gmsa_dj.tfvars
+++ b/terraform/azure_rke2_cluster/examples/gmsa_dj.tfvars
@@ -2,6 +2,7 @@ nodes = [
   {
     name     = "linux-server"
     image    = "linux"
+    size     = "Standard_B4als_v2"
     roles    = ["controlplane", "etcd", "worker"]
     replicas = 1
   },

--- a/terraform/azure_rke2_cluster/examples/linux.tfvars
+++ b/terraform/azure_rke2_cluster/examples/linux.tfvars
@@ -3,16 +3,13 @@ nodes = [
     name     = "linux-server"
     image    = "linux"
     size     = "Standard_B4als_v2"
-    scripts  = []
     roles    = ["etcd", "controlplane", "worker"]
     replicas = 1
   },
   {
-    name     = "windows-worker"
-    image    = "windows-2019-core"
-    scripts  = []
+    name     = "linux-worker"
+    image    = "linux"
     roles    = ["worker"]
     replicas = 1
-
   }
 ]

--- a/terraform/azure_rke2_cluster/examples/simple_2022.tfvars
+++ b/terraform/azure_rke2_cluster/examples/simple_2022.tfvars
@@ -2,6 +2,7 @@ nodes = [
   {
     name     = "linux-server"
     image    = "linux"
+    size     = "Standard_B4als_v2"
     roles    = ["etcd", "controlplane", "worker"]
     replicas = 1
   },

--- a/terraform/azure_rke2_cluster/variables.tf
+++ b/terraform/azure_rke2_cluster/variables.tf
@@ -45,7 +45,7 @@ variable "nodes" {
   type = list(object({
     name        = string
     image       = optional(string, "linux")
-    size        = optional(string, "Standard_B2s")
+    size        = optional(string, "Standard_B2als_v2")
     scripts     = optional(list(string), [])
     roles       = optional(list(string), ["worker"])
     replicas    = optional(number, 1)
@@ -56,6 +56,7 @@ variable "nodes" {
     {
       name     = "linux-server"
       image    = "linux"
+      size     = "Standard_B4als_v2"
       roles    = ["controlplane", "etcd", "worker"]
       replicas = 1
     },
@@ -72,7 +73,7 @@ variable "servers" {
   type = list(object({
     name        = string
     image       = optional(string, "linux")
-    size        = optional(string, "Standard_B2s")
+    size        = optional(string, "Standard_B2als_v2")
     scripts     = optional(list(string), [])
     domain_join = optional(bool, false)
   }))

--- a/terraform/internal/azure/servers/main.tf
+++ b/terraform/internal/azure/servers/main.tf
@@ -63,6 +63,7 @@ module "vms" {
   active_directory = each.value.domain_join ? var.active_directory : null
 
   name                = each.key
+  size                = each.value.size
   ssh_public_key_path = var.ssh_public_key_path
   image               = each.value.image
   scripts             = each.value.scripts

--- a/terraform/internal/azure/servers/variables.tf
+++ b/terraform/internal/azure/servers/variables.tf
@@ -31,7 +31,7 @@ variable "network" {
 variable "servers" {
   type = list(object({
     name   = string
-    size   = optional(string, "Standard_B2s")
+    size   = optional(string, "Standard_B2als_v2")
     subnet = optional(string, "external")
     image = optional(object({
       publisher = string

--- a/terraform/internal/azure/vm/variables.tf
+++ b/terraform/internal/azure/vm/variables.tf
@@ -51,7 +51,7 @@ variable "name" {
 variable "size" {
   type        = string
   description = "The size to use for this VM."
-  default     = "Standard_B2s"
+  default     = "Standard_B2als_v2"
 }
 
 variable "image" {

--- a/terraform/internal/rancher/fleet/bundle/files/bundle.yaml
+++ b/terraform/internal/rancher/fleet/bundle/files/bundle.yaml
@@ -11,6 +11,6 @@ spec:
   - clusterName: ${cluster_name}
   dependsOn: ${jsonencode(depends_on)}
   resources:
-  - name: ${name}.yaml
+  - name: templates/${name}.yaml
     content: ${base64encode(manifest)}
     encoding: "base64"

--- a/terraform/internal/rancher/fleet/bundle/main.tf
+++ b/terraform/internal/rancher/fleet/bundle/main.tf
@@ -33,8 +33,9 @@ data "helm_template" "chart" {
   create_namespace = true
   include_crds     = true
   # Cannot validate since the KUBECONFIG we are using is the local cluster's KUBECONFIG, not the downstream cluster's KUBECONFIG
-  validate     = false
-  kube_version = var.kubernetes_version
+  validate         = false
+  kube_version     = var.kubernetes_version
+  disable_webhooks = false
 }
 
 data "http" "manifest" {


### PR DESCRIPTION
- [feature] Added a `head.tfvars` to `azure_docker_rancher` to point to 2.8-head
- [feature] fixed `azure_docker_rancher` terraform to take in a `size` variable to avoid using a default
- [update] Modified the default `rancher_version` to `2.7.7` (from `2.7.3`)
- [update] Modified all Windows instances to use `Standard_B2als_v2`, although linux still uses `Standard_B4als_v2`
- [bug] Removed extra / from `gmsa.tfvars` certmanager URL
- [update] Using charts in `aiyengar2/Rancher-Plugin-gMSA` instead of those in draft repository. Removed GMSA hack as well since it was fixed in latest charts
- [bug] Modified Bundle to place resources in `templates/` directory, which causes Fleet to actually respect executing chart hooks