### PR TITLE
Use official repository when pulling chart artifacts

### DIFF
--- a/terraform/azure_rke2_cluster/examples/gmsa-all-supported-versions.tfvars
+++ b/terraform/azure_rke2_cluster/examples/gmsa-all-supported-versions.tfvars
@@ -7,8 +7,26 @@ nodes = [
     replicas = 1
   },
   {
-    name     = "windows-server"
-    image    = "windows"
+    name     = "windows-server-2019-core"
+    image    = "windows-2019-core"
+    roles    = ["worker"]
+    replicas = 1
+  },
+  {
+    name     = "windows-server-2019"
+    image    = "windows-2019"
+    roles    = ["worker"]
+    replicas = 1
+  },
+  {
+    name     = "windows-server-2022"
+    image    = "windows-2022"
+    roles    = ["worker"]
+    replicas = 1
+  },
+  {
+    name     = "windows-server-core-2022"
+    image    = "windows-2022-core"
     roles    = ["worker"]
     replicas = 1
   }

--- a/terraform/azure_rke2_cluster/examples/gmsa_dj.tfvars
+++ b/terraform/azure_rke2_cluster/examples/gmsa_dj.tfvars
@@ -46,14 +46,14 @@ apps = {
   }
 
   gmsa-crd = {
-    path         = "https://charts.rancher.io/assets/rancher-windows-gmsa-crd/rancher-windows-gmsa-crd-2.0.0.tgz"
+    path         = "https://github.com/rancher/Rancher-Plugin-gMSA/raw/main/assets/rancher-windows-gmsa-crd/rancher-windows-gmsa-crd-3.0.0.tgz"
     namespace    = "cattle-windows-gmsa-system"
     values       = {}
     dependencies = ["hack-gmsa-namespace"]
   }
 
   gmsa = {
-    path      = "https://charts.rancher.io/assets/rancher-windows-gmsa/rancher-windows-gmsa-2.0.0.tgz"
+    path      = "https://github.com/rancher/Rancher-Plugin-gMSA/raw/main/assets/rancher-windows-gmsa/rancher-windows-gmsa-3.0.0.tgz"
     namespace = "cattle-windows-gmsa-system"
     values = {
       credential = {


### PR DESCRIPTION
Removes references to assets included in forked repository and replaces them with references to the official repository. 

Also adds a new example for `gmsa` testing which deploys all supported windows OS versions at once