### PR TITLE
updating documentation: windows requires rsa keypairs

### DIFF
--- a/.spellchecker.dict.txt
+++ b/.spellchecker.dict.txt
@@ -50,6 +50,8 @@ VMs
 YAML
 sku
 PowerShell
+rsa
+RSA
 VPC
 VPCs
 subnet

--- a/docs/terraform/gmsa/environment_setup.md
+++ b/docs/terraform/gmsa/environment_setup.md
@@ -14,6 +14,8 @@ terraform -chdir=terraform/azure_active_directory init
 terraform -chdir=terraform/azure_rke2_cluster init
 ```
 
+> **Note**: Windows requires a rsa ssh key pair
+
 ### Connecting to Azure (and DigitalOcean)
 
 The Terraform modules used in this guide assume that the user has already authenticated their current machine to Azure by following the guidance of the [Azure Terraform Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure).

--- a/terraform/azure_rke2_cluster/variables.tf
+++ b/terraform/azure_rke2_cluster/variables.tf
@@ -95,6 +95,6 @@ variable "address_space" {
 
 variable "ssh_public_key_path" {
   type        = string
-  description = "The path to a public SSH key to be mounted on hosts."
+  description = "The path to a public SSH key to be mounted on hosts. This must be a RSA public key."
   default     = "~/.ssh/id_rsa.pub"
 }


### PR DESCRIPTION
Windows nodes currently require RSA keys when using Azure. Updating the documentation to reflect this via notes / descriptions. Otherwise the user will get `Only RSA SSH keys are supported by Azure` as an error when running TF scripts that provision windows nodes. 