### PR TITLE
Fix azure_docker_rancher terraform to use older Docker version and newer Rancher version

### DIFF
--- a/terraform/azure_docker_rancher/variables.tf
+++ b/terraform/azure_docker_rancher/variables.tf
@@ -17,7 +17,7 @@ variable "size" {
 variable "rancher_version" {
   type        = string
   description = "Version of Rancher to use. Find this on https://hub.docker.com/r/rancher/rancher."
-  default     = "2.7.7"
+  default     = "2.8.1"
 }
 
 variable "create_record" {
@@ -40,7 +40,7 @@ variable "registry_hostname" {
 
 variable "docker_version" {
   type        = string
-  default     = "24.0"
+  default     = "23.0"
   description = "Version of Docker to run Rancher on. Find this in https://github.com/rancher/install-docker/tree/master/dist."
 }
 


### PR DESCRIPTION
Currently, it seems like the install step for downloading Docker via `https://releases.rancher.com/install-docker/${docker_version}.sh` does not seem to work for `24.0`.

https://github.com/rancher/windows/blob/3b7a9e753e9750bab00dff8c2bff90ca4dcc8acc/terraform/azure_docker_rancher/files/install_docker.sh#L12-L13

More investigation is required before upgrading, but for now we can revert back to using a previous working Docker version.

This PR also bumps to use the `2.8.1` release of Rancher by default.

---

The error encountered is as follows:

```bash
root@<REDACTED>:~# curl https://releases.rancher.com/install-docker/24.0.sh | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 24599  100 24599    0     0   212k      0 --:--:-- --:--:-- --:--:--  212k
# Executing docker install script, commit: e5543d473431b782227f8908005543bb4389b8de
Warning: the "docker" command appears to already exist on this system.

If you already have Docker installed, this script can cause trouble, which is
why we're displaying this warning and provide the opportunity to cancel the
installation.

If you installed the current Docker package using this script and are using it
again to update Docker, you can safely ignore this message.

You may press Ctrl+C now to abort this script.
+ sleep 20
+ sh -c apt-get update -qq >/dev/null
+ sh -c DEBIAN_FRONTEND=noninteractive apt-get install -y -qq apt-transport-https ca-certificates curl >/dev/null
+ sh -c install -m 0755 -d /etc/apt/keyrings
+ sh -c curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" | gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg
+ sh -c chmod a+r /etc/apt/keyrings/docker.gpg
+ sh -c echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list
+ sh -c apt-get update -qq >/dev/null
INFO: Searching repository for VERSION '24.0.7'
INFO: apt-cache madison docker-ce | grep '24.0.7' | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3

ERROR: '24.0.7' not found amongst apt-cache madison results
```