### PR TITLE
Fix Windows node automatic joining

### DIFF
--- a/terraform/azure_rke2_cluster/variables.tf
+++ b/terraform/azure_rke2_cluster/variables.tf
@@ -6,7 +6,7 @@ variable "name" {
 variable "kubernetes_version" {
   type        = string
   description = "The version of RKE2 that you would like to use to provision a cluster."
-  default     = "v1.24.17+rke2r1"
+  default     = "v1.25.16+rke2r1"
 }
 
 variable "active_directory" {

--- a/terraform/internal/rancher/rke2/planner/main.tf
+++ b/terraform/internal/rancher/rke2/planner/main.tf
@@ -16,7 +16,7 @@ locals {
           }) : "echo \"No need to install etcdctl.\""
           ] : [
           templatefile("${path.module}/files/windows/install_containers.ps1", {}),
-          format("%s -Worker", var.registration_commands.windows),
+          var.registration_commands.windows,
           templatefile("${path.module}/files/windows/rke2_profile.ps1", {})
         ]
       }


### PR DESCRIPTION
While using the terraform over the last few days I've noticed that the Windows nodes do not automatically join the cluster during the bootstrap phase. After looking at the scheduled task logs I've found that the `-Worker` flag was being defined twice in the registration command.

This is due to the fact that the registration command generated by Rancher will already have that flag provided, but the terraform is attempting to provide it as well. This PR fixes the issue by relying on the flag being provided automatically by Rancher when generating the registration command. If windows servers ever become a thing then we will want to reintroduce this formatting, but that won't happen for a while.