### PR TITLE
Remove disclaimer from windows support doc for RKE1

### DIFF
--- a/docs/general/windows_support_across_cloud_providers.md
+++ b/docs/general/windows_support_across_cloud_providers.md
@@ -6,8 +6,6 @@ The Rancher Windows team has a goal to add automated infrastructure in the [`ter
 
 The Rancher Windows team supports Windows clusters provisioned using [RKE2](https://github.com/rancher/rke2).
 
-> **Note**: RKE1 Windows is no longer supported. Please see [SUSE Support's document](https://www.suse.com/support/kb/doc/?id=000020684) on this or our docs in [`docs/distributions/rke1_windows.md`](../distributions/rke1_windows.md) for more information.
-
 - [Azure](https://support.microsoft.com/en-us/topic/windows-server-images-for-january-2022-51a88228-17f6-422d-a593-b09ff9f20632)
   - `Windows Server, version 2022`
   - `Windows Server 2019`


### PR DESCRIPTION
There's no need to repeat this disclaimer in the Windows support docs. The previous line clearly indicates we support just RKE2 (or else we would have said it).