### PR TITLE
SQL Server Automation

### DIFF
--- a/terraform/azure_active_directory/main.tf
+++ b/terraform/azure_active_directory/main.tf
@@ -43,7 +43,7 @@ module "server" {
   servers = [
     {
       name  = var.name
-      image = module.images.source_images["windows"]
+      image = module.images.source_images["windows-2022"]
       scripts = [
         local.install_active_directory,
         local.setup_active_directory,

--- a/terraform/azure_active_directory/main.tf
+++ b/terraform/azure_active_directory/main.tf
@@ -11,8 +11,9 @@ module "server" {
     type = "simple"
     // We hard-code a unique address_space to avoid conflicts with other modules
     // creating a peering relationship with the network created by this module
-    address_space = var.address_space
-    airgap        = false
+    address_space  = var.address_space
+    airgap         = false
+    vpc_only_ports = []
     open_ports = [
       // DirectAccess
       "441",

--- a/terraform/azure_docker_rancher/main.tf
+++ b/terraform/azure_docker_rancher/main.tf
@@ -65,9 +65,10 @@ module "server" {
     type = "simple"
     // We hard-code a unique address_space to avoid conflicts with other modules
     // creating a peering relationship with the network created by this module
-    address_space = var.address_space
-    airgap        = false
-    open_ports    = ["80", "443", "6443"]
+    address_space  = var.address_space
+    airgap         = false
+    open_ports     = ["80", "443", "6443"]
+    vpc_only_ports = []
   }
 
   servers = [

--- a/terraform/azure_rke2_cluster/examples/gmsa_sql.tfvars
+++ b/terraform/azure_rke2_cluster/examples/gmsa_sql.tfvars
@@ -1,0 +1,93 @@
+nodes = [
+  {
+    name     = "linux-server"
+    image    = "linux"
+    size     = "Standard_B4als_v2"
+    roles    = ["controlplane", "etcd", "worker"]
+    replicas = 1
+  },
+  {
+    name     = "windows-worker"
+    image    = "windows-2022"
+    roles    = ["worker"]
+    replicas = 1
+  }
+]
+
+servers = [
+  {
+    name  = "sql-server"
+    image = "windows-2022"
+    // A SQL server should always be domain joined
+    domain_join = true
+    sql_server  = true
+  }
+]
+
+// Ports which should not be exposed to the internet
+vpc_only_ports = [
+  // SQL server API
+  "1433",
+]
+
+apps = {
+  cert-manager-crd = {
+    path      = "https://github.com/cert-manager/cert-manager/releases/download/v1.12.4/cert-manager.crds.yaml"
+    namespace = "cert-manager"
+  }
+
+  cert-manager = {
+    path         = "https://charts.jetstack.io/charts/cert-manager-v1.12.4.tgz"
+    namespace    = "cert-manager"
+    values       = {}
+    dependencies = ["cert-manager-crd"]
+  }
+
+  rancher-gmsa-webhook-crd = {
+    path      = "https://github.com/rancher/Rancher-Plugin-gMSA/raw/main/assets/rancher-gmsa-webhook-crd/rancher-gmsa-webhook-crd-0.1.0.tgz"
+    namespace = "cattle-windows-gmsa-system"
+    values    = {}
+  }
+
+  rancher-gmsa-webhook = {
+    path         = "https://github.com/rancher/Rancher-Plugin-gMSA/raw/main/assets/rancher-gmsa-webhook/rancher-gmsa-webhook-0.1.0.tgz"
+    namespace    = "cattle-windows-gmsa-system"
+    values       = {}
+    dependencies = ["rancher-gmsa-webhook-crd", "cert-manager"]
+  }
+
+  windows-ad-setup = {
+    path      = "charts/windows-ad-setup"
+    namespace = "cattle-windows-gmsa-system"
+    # Comment this out if you are not using the Active Directory Terraform module
+    #
+    # This will cause a failure unless you have run the script in the setup_integration
+    # output of the Active Directory Terraform module
+    #
+    # Alternatively, you can manually create the expected `values.json` for an external Active Directory
+    values_file  = "dist/active_directory/values.json"
+    dependencies = ["rancher-gmsa-webhook"]
+  }
+
+  rancher-gmsa-plugin-installer = {
+    path      = "https://github.com/rancher/Rancher-Plugin-gMSA/raw/main/assets/rancher-gmsa-plugin-installer/rancher-gmsa-plugin-installer-0.1.0.tgz"
+    namespace = "cattle-windows-gmsa-system"
+    values    = {}
+  }
+
+  rancher-gmsa-account-provider = {
+    path         = "https://github.com/rancher/Rancher-Plugin-gMSA/raw/main/assets/rancher-gmsa-account-provider/rancher-gmsa-account-provider-0.1.0.tgz"
+    namespace    = "cattle-windows-gmsa-system"
+    values       = {}
+    dependencies = ["cert-manager"]
+  }
+
+  windows-gmsa-webserver = {
+    path      = "charts/windows-gmsa-webserver"
+    namespace = "cattle-wins-system"
+    values = {
+      gmsa = "gmsa1-ccg"
+    }
+    dependencies = ["windows-ad-setup", "rancher-gmsa-plugin-installer", "rancher-gmsa-account-provider"]
+  }
+}

--- a/terraform/azure_rke2_cluster/examples/sql.tfvars
+++ b/terraform/azure_rke2_cluster/examples/sql.tfvars
@@ -1,0 +1,31 @@
+nodes = [
+  {
+    name     = "linux-server"
+    image    = "linux"
+    size     = "Standard_B4als_v2"
+    roles    = ["controlplane", "etcd", "worker"]
+    replicas = 1
+  },
+  {
+    name     = "windows-worker"
+    image    = "windows-2022"
+    roles    = ["worker"]
+    replicas = 1
+  }
+]
+
+servers = [
+  {
+    name  = "sql-server"
+    image = "windows-2022"
+    // A SQL server should always be domain joined
+    domain_join = true
+    sql_server  = true
+  }
+]
+
+// Ports which should not be exposed to the internet
+vpc_only_ports = [
+  // SQL server API
+  "1433",
+]

--- a/terraform/azure_rke2_cluster/files/setup_sql.ps1
+++ b/terraform/azure_rke2_cluster/files/setup_sql.ps1
@@ -1,0 +1,194 @@
+# This script sets up MS SQL 2022. It does so by downloading the installer for the 2022 developer edition, using the installer to download the complete installation ISO
+# and then extracting the ISO onto the disk. Once the setup media has been extracted, it uses PowerShell DSC to automate the installation and configuration
+# of the SQL server via the 'setup.exe' binary.
+
+$adminUser ='${windows_AD_user}'
+$adminpassword = '${windows_AD_password}'
+$domain = '${windows_AD_domain}'
+$localAdminUser = "$env:computername\$adminuser"
+
+if ($adminUser -eq "") {
+    Write-Host "Empty administrator username, cannot setup SQL server."
+    exit 1
+}
+
+if ($adminpassword -eq "") {
+    Write-Host "Empty administrator password, cannot setup SQL server."
+    exit 1
+}
+
+# Set the domain for the AD admin user
+if ($domain -ne "")
+{
+    $adminUser = $domain + "\" + $adminUser
+}
+
+Write-Host "Attempting to setup sql server"
+
+New-NetFirewallRule -DisplayName 'sql-server-domain-tcp' `
+                    -LocalPort 1433 -Action Allow `
+                    -Profile 'Domain' `
+                    -Protocol TCP `
+                    -Direction Inbound
+
+New-NetFirewallRule -DisplayName 'sql-server-private-tcp' `
+                    -LocalPort 1433 -Action Allow `
+                    -Profile 'Private' `
+                    -Protocol TCP `
+                    -Direction Inbound
+
+Write-Host "Installing required Modules"
+Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+Install-Module -Name SqlServerDsc -Force
+Install-Module -Name SqlServer -Force
+Install-Module -Name xPSDesiredStateConfiguration -RequiredVersion 9.1.0 -Force
+
+# Create a working directory
+Write-Host "Creating installation directory C:\sql"
+mkdir C:\sql
+
+# Download the media installer
+Write-Host "Downloading MS SQL 2022 Installer"
+wget "https://go.microsoft.com/fwlink/p/?linkid=2215158&clcid=0x409&culture=en-us&country=us" -usebasicparsing -outfile setup.exe
+
+# Download the ISO so we can install headless
+Write-Host "Downloading installation ISO"
+cmd.exe /c 'setup.exe /q /ACTION=Download /MEDIATYPE=iso /MEDIAPATH=C:\Users\adminuser'
+
+Write-Host "Mounting and extracting ISO contents"
+$isoPath = "C:\Users\adminuser\SQLServer2022-x64-ENU-Dev.iso"
+$destinationPath = "C:\sql"
+
+# Extract the ISO onto the C:\ drive
+Mount-DiskImage -ImagePath $isoPath
+$drive = (Get-DiskImage -ImagePath $isoPath | Get-Volume).DriveLetter
+Copy-Item -Path "$drive`:\*" -Destination $destinationPath -Force -Recurse
+Dismount-DiskImage -ImagePath $isoPath
+
+cd C:\sql
+
+# Start to create the DSC file
+Write-Host "Creating DSC"
+
+# ref https://github.com/dsccommunity/SqlServerDsc/blob/main/source/Examples/Resources/SqlSetup/8-InstallDefaultInstanceSingleServer2022OrLater.ps1#L29
+$conf = @"
+Configuration SQLInstall
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory=`$true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        `$SqlInstallCredential,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        `$SqlAdministratorCredential = `$SqlInstallCredential,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        `$SqlServerAdminName,
+
+        [Parameter()]
+        [String]
+        `$LocalAccount,
+
+        [Parameter(Mandatory=`$true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        `$SqlServiceCredential,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        `$SqlAgentServiceCredential = `$SqlServiceCredential
+    )
+
+    Import-DscResource -ModuleName 'xPSDesiredStateConfiguration' -ModuleVersion '9.1.0'
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        WindowsFeature 'NetFramework35'
+        {
+            Name   = 'NET-Framework-Core'
+            Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes built-in Everyone has read permission to the share and path.
+            Ensure = 'Present'
+        }
+
+        WindowsFeature 'NetFramework45'
+        {
+            Name   = 'NET-Framework-45-Core'
+            Ensure = 'Present'
+        }
+
+        SqlSetup 'InstallDefaultInstance'
+        {
+            InstanceName           = 'MSSQLSERVER'
+            Features               = 'SQLENGINE'
+            SQLCollation           = 'SQL_Latin1_General_CP1_CI_AS'
+            SQLSvcAccount          = `$SqlAdministratorCredential
+            AgtSvcAccount          = `$SqlAdministratorCredential
+            ASSvcAccount           = `$SqlAdministratorCredential
+            SQLSysAdminAccounts    = `$SqlServerAdminName, `$LocalAccount, 'NT AUTHORITY\SYSTEM'
+            InstallSharedDir       = 'C:\Program Files\Microsoft SQL Server'
+            InstallSharedWOWDir    = 'C:\Program Files (x86)\Microsoft SQL Server'
+            InstanceDir            = 'C:\Program Files\Microsoft SQL Server'
+            InstallSQLDataDir      = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data'
+            SQLUserDBDir           = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data'
+            SQLUserDBLogDir        = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data'
+            SQLTempDBDir           = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data'
+            SQLTempDBLogDir        = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data'
+            SQLBackupDir           = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Backup'
+            ASServerMode           = 'TABULAR'
+            SourcePath             = 'C:\sql'
+            UpdateEnabled          = 'False'
+            ProductCoveredbySA     = 1
+            ForceReboot            = 0
+            SqlTempdbFileCount     = 4
+            SqlTempdbFileSize      = 1024
+            SqlTempdbFileGrowth    = 512
+            SqlTempdbLogFileSize   = 128
+            SqlTempdbLogFileGrowth = 64
+
+            PsDscRunAsCredential = `$SqlInstallCredential
+
+            DependsOn            = '[WindowsFeature]NetFramework35', '[WindowsFeature]NetFramework45'
+        }
+    }
+}
+"@
+
+Set-Content -Path installsql.ps1 -Value $conf
+
+# source the DSC File
+. .\installsql.ps1
+
+# Since this is a short lived dev environment, allow insecure passwords
+$cd = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+        }
+    )
+}
+
+# Setup a PS credential so the MS SQL service can run as the local user
+$SqlSvcAcc = $adminUser
+$password = ($adminpassword | ConvertTo-SecureString -AsPlainText -Force)
+$SqlSvcCred = new-object -typename System.Management.Automation.PSCredential -argumentlist $sqlSvcAcc,$password
+
+# generate the mof file
+Write-Host "Generating DSC MOF File"
+SQLInstall -SqlServerAdminName "$adminUser" -LocalAccount $localAdminUser -SqlInstallCredential $SqlSvcCred -SqlAdministratorCredential $SqlSvcCred -SqlServiceCredential $SqlSvcCred -SqlAgentServiceCredential $SqlSvcCred -ConfigurationData $cd
+
+Write-Host "Executing DSC"
+Start-DscConfiguration -Path C:\sql\SQLInstall -Wait -Force -Verbose
+
+Write-Host "Done Installing SQL Server"
+
+

--- a/terraform/azure_rke2_cluster/files/setup_sql_database.ps1
+++ b/terraform/azure_rke2_cluster/files/setup_sql_database.ps1
@@ -1,0 +1,60 @@
+Write-Host "Setting up test database..."
+# dba tools module allows us to make sql queries from powershell
+Install-Module -Name "dbatools" -Force
+Set-Dbatoolsinsecureconnection
+
+$testDBName = '${test_database_name}'
+$testTable = '${test_table_name}'
+
+if ($testDBName -eq "" ) {
+    Write-Host "Did not provide a test DB name"
+    exit 1
+}
+
+if ($testTable -eq "" ) {
+    Write-Host "Did not provide a test table name"
+    exit 1
+}
+
+Write-Host "Creating '$testDBName' database"
+# Create a test database and table
+New-DbaDatabase -SqlInstance localhost\MSSQLSERVER -Name $testDBName
+
+$cols = @( )
+$cols += @{
+    Name              = 'Id'
+    Type              = 'varchar'
+    MaxLength         = 36
+    DefaultExpression = 'NEWID()'
+}
+$cols += @{
+    Name          = 'Value'
+    Type          = 'varchar'
+    MaxLength     = 36
+}
+
+Write-Host "Creating '$testTable' table"
+New-DbaDbTable -SqlInstance localhost\MSSQLSERVER -Database $testDBName -Name $testTable -ColumnMap $cols
+
+Write-Host "Adding some data..."
+
+$insertquery="
+INSERT INTO [dbo].[$testTable]
+           ([Id],[Value])
+     VALUES
+           ('1','TEST' )
+GO
+"
+
+Invoke-SQLcmd -ServerInstance 'localhost' -query $insertquery -Database $testDBName -TrustServerCertificate
+
+# Enable TCP IP so others can connect
+Write-Host "Enabling TCP IP for SQL server"
+$wmi = New-Object 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer' localhost
+$tcp = $wmi.ServerInstances['MSSQLSERVER'].ServerProtocols['Tcp']
+$tcp.IsEnabled = $true
+$tcp.Alter()
+
+Write-Host "Restarting service and waiting 30 seconds..."
+Restart-Service -Name MSSQLSERVER -Force
+Start-Sleep 30

--- a/terraform/azure_rke2_cluster/files/setup_sql_management_ui.ps1
+++ b/terraform/azure_rke2_cluster/files/setup_sql_management_ui.ps1
@@ -1,0 +1,9 @@
+#  This tool is very useful and without it there is no UI for browsing the sql server. However, this must be done as
+#  the last step in the process as it takes a considerable amount of time to complete (> 10 mins).
+Write-Host "Installing SQL Server Management UI, the SQL server can still be used during this operation. This is will take a while."
+cd ~
+Write-Host "Downloading instllation exe"
+wget "https://aka.ms/ssmsfullsetup" -usebasicparsing -outfile smss-install.exe
+Write-Host "Download complete, starting install"
+./smss-install.exe /passive
+Write-Host "Installation complete"

--- a/terraform/azure_rke2_cluster/files/setup_sql_users.ps1
+++ b/terraform/azure_rke2_cluster/files/setup_sql_users.ps1
@@ -1,0 +1,36 @@
+# Add AD users and roles to the test database, including the default GMSA
+Write-Host "Creating user logins and accounts"
+
+$testDBName = '${test_database_name}'
+
+if ($testDBName -eq "") {
+    Write-Host "Did not provide a test database name"
+    exit 1
+}
+
+$logonAndUsers = @(
+    [PSCustomObject]@{
+        Logon = "ad\GMSA1$"
+        Username = "defaultGmsa"
+    }
+    [PSCustomObject]@{
+        Logon = "ad\User1"
+        Username = "testUser"
+    }
+)
+
+foreach($user in $logonAndUsers) {
+    $u = $user.Username
+    $l = $user.Logon
+    Write-Host "Creating Logon for $l, assocating login with user $u, and settings read write permission to database $testDBName"
+    $q = "
+     CREATE LOGIN [$l] FROM WINDOWS;
+     USE $testDBName;
+     CREATE USER $u FOR LOGIN [$l];
+     ALTER ROLE db_datareader ADD MEMBER $u;
+     ALTER ROLE db_datawriter ADD MEMBER $u;
+    "
+    Invoke-SQLcmd -ServerInstance 'localhost' -query $q -TrustServerCertificate
+}
+
+Write-Host "Done setting up SQL Server!"

--- a/terraform/azure_rke2_cluster/main.tf
+++ b/terraform/azure_rke2_cluster/main.tf
@@ -46,24 +46,28 @@ module "planner" {
 
 locals {
 
-  sqlScript = var.active_directory == null ? [] : concat([templatefile("${path.module}/files/setup_sql.ps1", {
+  sqlScript = var.active_directory == null ? [] : [templatefile("${path.module}/files/setup_sql.ps1", {
     windows_AD_user     = var.active_directory.join_credentials.username
     windows_AD_password = var.active_directory.join_credentials.password
     windows_AD_domain   = var.active_directory.domain_name
-    })],
-    [templatefile("${path.module}/files/setup_sql_database.ps1", {
+    }),
+    templatefile("${path.module}/files/setup_sql_database.ps1", {
       test_database_name = "sqlTest"
       test_table_name    = "testTable"
-    })],
-    [templatefile("${path.module}/files/setup_sql_users.ps1", {
+    }),
+    templatefile("${path.module}/files/setup_sql_users.ps1", {
       test_database_name = "sqlTest"
-    })],
+    }),
     // The sql management installation takes a very long time,
     // this script should always be executed last. The SQL server
     // can be used while this script is executing, however no UI
     // application will be available.
-    [file("${path.module}/files/setup_sql_management_ui.ps1")]
-  )
+    file("${path.module}/files/setup_sql_management_ui.ps1")
+  ]
+
+}
+
+locals {
 
   servers = merge({
     for name, node in module.planner.plan : name => {

--- a/terraform/azure_rke2_cluster/main.tf
+++ b/terraform/azure_rke2_cluster/main.tf
@@ -46,24 +46,24 @@ module "planner" {
 
 locals {
 
-     sqlScript = var.active_directory == null ? [] : concat([templatefile("${path.module}/files/setup_sql.ps1", {
-        windows_AD_user = var.active_directory.join_credentials.username
-        windows_AD_password = var.active_directory.join_credentials.password
-        windows_AD_domain = var.active_directory.domain_name
-      })],
-      [templatefile("${path.module}/files/setup_sql_database.ps1", {
-        test_database_name = "sqlTest"
-        test_table_name = "testTable"
-      })],
-      [templatefile("${path.module}/files/setup_sql_users.ps1", {
-        test_database_name = "sqlTest"
-      })],
-       // The sql management installation takes a very long time,
-       // this script should always be executed last. The SQL server
-       // can be used while this script is executing, however no UI
-       // application will be available.
-      [file("${path.module}/files/setup_sql_management_ui.ps1")]
-    )
+  sqlScript = var.active_directory == null ? [] : concat([templatefile("${path.module}/files/setup_sql.ps1", {
+    windows_AD_user     = var.active_directory.join_credentials.username
+    windows_AD_password = var.active_directory.join_credentials.password
+    windows_AD_domain   = var.active_directory.domain_name
+    })],
+    [templatefile("${path.module}/files/setup_sql_database.ps1", {
+      test_database_name = "sqlTest"
+      test_table_name    = "testTable"
+    })],
+    [templatefile("${path.module}/files/setup_sql_users.ps1", {
+      test_database_name = "sqlTest"
+    })],
+    // The sql management installation takes a very long time,
+    // this script should always be executed last. The SQL server
+    // can be used while this script is executing, however no UI
+    // application will be available.
+    [file("${path.module}/files/setup_sql_management_ui.ps1")]
+  )
 
   servers = merge({
     for name, node in module.planner.plan : name => {

--- a/terraform/azure_rke2_cluster/variables.tf
+++ b/terraform/azure_rke2_cluster/variables.tf
@@ -76,14 +76,27 @@ variable "servers" {
     size        = optional(string, "Standard_B2als_v2")
     scripts     = optional(list(string), [])
     domain_join = optional(bool, false)
+    sql_server  = optional(bool, false)
   }))
   description = "Additional servers that should be created alongside your cluster. These servers will automatically be added to the same network as the cluster."
   default     = []
 }
 
+
+// It's important to note that currently both vpc_only_ports and open_ports are top level attributes that
+// apply to all servers in the cluster and cannot be specified per-server.
+// TODO: Fix this so that it can be done both at a global level and server specific level.
+
+
 variable "open_ports" {
   type        = list(string)
   description = "Ports to leave on the external (default) subnet."
+  default     = []
+}
+
+variable "vpc_only_ports" {
+  type        = list(string)
+  description = "Ports that should only be accessible by other machines in the VPC"
   default     = []
 }
 

--- a/terraform/azure_server/main.tf
+++ b/terraform/azure_server/main.tf
@@ -55,6 +55,7 @@ module "server" {
     address_space = var.address_space
     airgap        = false
     open_ports    = var.open_ports
+    vpc_ports     = var.vpc_only_ports
   }
 
   servers = [

--- a/terraform/azure_server/variables.tf
+++ b/terraform/azure_server/variables.tf
@@ -17,6 +17,13 @@ variable "open_ports" {
   default     = []
 }
 
+variable "vpc_only_ports" {
+  type        = list(string)
+  description = "Ports that should only be accessible by other machines in the VPC"
+  default     = []
+}
+
+
 variable "active_directory" {
   type = object({
     name                = string

--- a/terraform/internal/azure/network/main.tf
+++ b/terraform/internal/azure/network/main.tf
@@ -1,10 +1,11 @@
 module "network" {
   source = "../../rancher/network"
 
-  type          = var.type
-  address_space = var.address_space
-  airgap        = var.airgap
-  open_ports    = var.open_ports
+  type           = var.type
+  address_space  = var.address_space
+  airgap         = var.airgap
+  open_ports     = var.open_ports
+  vpc_only_ports = var.vpc_only_ports
 }
 
 locals {

--- a/terraform/internal/azure/network/variables.tf
+++ b/terraform/internal/azure/network/variables.tf
@@ -30,6 +30,12 @@ variable "airgap" {
   default     = false
 }
 
+variable "vpc_only_ports" {
+  type        = list(string)
+  description = "List of ports and/or port ranges that should only be accessible from other machines in the VPC."
+  default     = []
+}
+
 variable "open_ports" {
   type        = list(string)
   description = "Ports to leave on the external (default) subnet."

--- a/terraform/internal/azure/servers/main.tf
+++ b/terraform/internal/azure/servers/main.tf
@@ -11,12 +11,13 @@ module "network" {
   resource_group = var.name
   location       = var.location
 
-  type          = var.network.type
-  address_space = var.network.address_space
-  airgap        = var.network.airgap
-  open_ports    = var.network.open_ports
-  peers         = var.active_directory != null ? { "${var.active_directory.name}" = {} } : {}
-  dns_servers   = var.active_directory != null ? [var.active_directory.ip_address] : null
+  type           = var.network.type
+  address_space  = var.network.address_space
+  airgap         = var.network.airgap
+  open_ports     = var.network.open_ports
+  vpc_only_ports = var.network.vpc_only_ports
+  peers          = var.active_directory != null ? { "${var.active_directory.name}" = {} } : {}
+  dns_servers    = var.active_directory != null ? [var.active_directory.ip_address] : null
 
   depends_on = [
     module.resource_group

--- a/terraform/internal/azure/servers/variables.tf
+++ b/terraform/internal/azure/servers/variables.tf
@@ -15,16 +15,18 @@ variable "name" {
 
 variable "network" {
   type = object({
-    type          = string
-    address_space = string
-    airgap        = bool
-    open_ports    = list(string)
+    type           = string
+    address_space  = string
+    airgap         = bool
+    open_ports     = list(string)
+    vpc_only_ports = list(string)
   })
   default = {
-    type          = "simple"
-    address_space = "10.0.256.0/16"
-    airgap        = false
-    open_ports    = []
+    type           = "simple"
+    address_space  = "10.0.256.0/16"
+    airgap         = false
+    open_ports     = []
+    vpc_only_ports = []
   }
 }
 

--- a/terraform/internal/azure/vm/files/ad_domain_join.ps1
+++ b/terraform/internal/azure/vm/files/ad_domain_join.ps1
@@ -1,9 +1,11 @@
-$domainName = "${domain_name}"
-$machineUsername = "${machine_username}"
-$machinePassword = "${machine_password}"
-$activeDirectoryUsername = "${domain_netbios_name}\${active_directory_username}"
-$activeDirectoryPassword = "${active_directory_password}"
-$networkPrefixLength = "${network_prefix_length}"
+# Ensure single quotes are used, as double quotes may result in an
+# attempt to expand nonexistent variables or execute commands via $()
+$domainName = '${domain_name}'
+$machineUsername = '${machine_username}'
+$machinePassword = '${machine_password}'
+$activeDirectoryUsername = '${domain_netbios_name}\${active_directory_username}'
+$activeDirectoryPassword = '${active_directory_password}'
+$networkPrefixLength = '${network_prefix_length}'
 
 Write-Output "Installing Windows Feature RSAT-AD-Tools..."
 Install-WindowsFeature -Name RSAT-AD-Tools

--- a/terraform/internal/rancher/network/main.tf
+++ b/terraform/internal/rancher/network/main.tf
@@ -91,25 +91,25 @@ locals {
   flannel_rules = yamldecode(file("${path.module}/files/flannel.yaml"))["rules"]
 
   # Open Ports
-  open_port_rules = flatten([
-    for port in var.open_ports : [
-      {
-        name        = "open-${port}"
-        description = "Allows TCP traffic to port ${port} on hosts in the external subnet"
-        direction   = "inbound"
-        action      = "allow"
-        port_range  = port
-        from        = "*"
-        to          = "external"
-        protocol    = "*"
-      },
-    ]
-  ])
+  open_port_rules = [
+    for port in var.open_ports : {
+      name        = "open-${port}"
+      description = "Allows TCP traffic to port ${port} on hosts in the external subnet"
+      direction   = "inbound"
+      action      = "allow"
+      port_range  = port
+      from        = "*"
+      to          = "external"
+      protocol    = "*"
+    }
+  ]
 
   vpc_only_port_rules = flatten([
     for port in var.vpc_only_ports : [
       // NOTE: Deny rules must be applied first in order for the
-      //       priority values to be ordered correctly
+      //       priority values to be ordered correctly.
+      //       This can be removed when we rectify the simple.yaml
+      //       rules in the future
       {
         name        = "vpc-only-${port}"
         description = "Denies all traffic from machines outside the VPC to ${port}"

--- a/terraform/internal/rancher/network/main.tf
+++ b/terraform/internal/rancher/network/main.tf
@@ -92,15 +92,42 @@ locals {
 
   # Open Ports
   open_port_rules = flatten([
-    for port in concat(var.open_ports) : [
+    for port in var.open_ports : [
       {
         name        = "open-${port}"
         description = "Allows TCP traffic to port ${port} on hosts in the external subnet"
         direction   = "inbound"
         action      = "allow"
-        port_range  = "${port}"
+        port_range  = port
         from        = "*"
         to          = "external"
+        protocol    = "*"
+      },
+    ]
+  ])
+
+  vpc_only_port_rules = flatten([
+    for port in var.vpc_only_ports : [
+      // NOTE: Deny rules must be applied first in order for the
+      //       priority values to be ordered correctly
+      {
+        name        = "vpc-only-${port}"
+        description = "Denies all traffic from machines outside the VPC to ${port}"
+        direction   = "inbound"
+        action      = "deny"
+        port_range  = port
+        from        = "*"
+        to          = "*"
+        protocol    = "*"
+      },
+      {
+        name        = "vpc-only-${port}"
+        description = "Allow all traffic from machines inside the VPC to ${port}"
+        direction   = "inbound"
+        action      = "allow"
+        port_range  = port
+        from        = "vpc"
+        to          = "*"
         protocol    = "*"
       },
     ]
@@ -110,6 +137,7 @@ locals {
   simple_rule_template = concat(
     var.airgap ? local.airgap_rules : local.basic_rules,
     local.remote_rules,
+    local.vpc_only_port_rules,
     local.open_port_rules
   )
 

--- a/terraform/internal/rancher/network/variables.tf
+++ b/terraform/internal/rancher/network/variables.tf
@@ -26,6 +26,12 @@ variable "airgap" {
   default     = false
 }
 
+variable "vpc_only_ports" {
+  type        = list(string)
+  description = "List of ports and/or port ranges that should only be accessible from other machines in the VPC."
+  default     = []
+}
+
 variable "open_ports" {
   type        = list(string)
   description = "Ports to leave on the external (default) subnet."


### PR DESCRIPTION
This PR adds terraform automation for automatically standing up a VM running MS SQL server 2022 development edition. In order for this automation to be used, an active directory instance must already be provisioned and the appropriate active directory environment variables must be provided to `terraform apply`. Specific changes include

+ Introduction of several new bootstrap scripts to automatically install and configure the SQL server, adding in testing tables and data as well as automatically creating SQL users associated with existing active directory users / logins 
+ Introduction of a new `vpc_only_ports` field when creating servers in Azure. This field can be used to create NSG allow rules for specific ports that are accessible only by the other machines the VPC and any peer'ed networks 
    + These ports will also need to be opened in the Windows file wall as well for proper exposure, which should be done in a bootstrap script
+ Fixes an intermittent issue with joining VMs to a domain, due to the content of the automatically generated user passwords. 
+ Updates the default server version used when creating an active directory instance to windows 2022 