### PR TITLE
fixing vpc only ports references, updates for 2025

### DIFF
--- a/terraform/azure_rke2_cluster/examples/simple_2022.tfvars
+++ b/terraform/azure_rke2_cluster/examples/simple_2022.tfvars
@@ -8,7 +8,7 @@ nodes = [
   },
   {
     name     = "windows-worker"
-    image    = "windows-2022-core"
+    image    = "windows-2022"
     roles    = ["worker"]
     replicas = 1
   }

--- a/terraform/azure_rke2_cluster/variables.tf
+++ b/terraform/azure_rke2_cluster/variables.tf
@@ -6,7 +6,7 @@ variable "name" {
 variable "kubernetes_version" {
   type        = string
   description = "The version of RKE2 that you would like to use to provision a cluster."
-  default     = "v1.30.9+rke2r1"
+  default     = "v1.32.5+rke2r1"
 }
 
 variable "active_directory" {

--- a/terraform/azure_server/README.md
+++ b/terraform/azure_server/README.md
@@ -56,14 +56,14 @@ terraform -chdir=terraform/azure_server destroy -var-file="examples/windows.tfva
 
 Windows Servers do not come configured with support for containerized workloads out of the box; in order for a Windows Server to run containerized workloads, you must install the optional `Containers` feature.
 
-To trigger the module to create a Windows node with the `Containers` feature enabled, use the example from [`examples/windows_containers.tfvars`](./examples/windows_containers.tfvars)
+To trigger the module to create a Windows node with the `Containers` feature enabled, use the example from [`examples/windows_2022_containers.tfvars`](./examples/windows_containers.tfvars)
 
 ```bash
-terraform -chdir=terraform/azure_server apply -var-file="examples/windows_containers.tfvars"
+terraform -chdir=terraform/azure_server apply -var-file="examples/windows_2022_containers.tfvars"
 
 terraform -chdir=terraform/azure_server output
 
-terraform -chdir=terraform/azure_server destroy -var-file="examples/windows_containers.tfvars"
+terraform -chdir=terraform/azure_server destroy -var-file="examples/windows_2022_containers.tfvars"
 ```
 
 > **Note:** The node will be automatically restarted once the Containers feature installs, due to this you should wait about 1-2 minutes after provisioning to register the node.

--- a/terraform/azure_server/examples/windows_2019_debug.tfvars
+++ b/terraform/azure_server/examples/windows_2019_debug.tfvars
@@ -1,0 +1,2 @@
+image       = "windows-2019"
+debug_tools = true

--- a/terraform/azure_server/examples/windows_2025_debug.tfvars
+++ b/terraform/azure_server/examples/windows_2025_debug.tfvars
@@ -1,0 +1,2 @@
+image       = "windows-2025"
+debug_tools = true

--- a/terraform/azure_server/main.tf
+++ b/terraform/azure_server/main.tf
@@ -55,7 +55,7 @@ module "server" {
     address_space = var.address_space
     airgap        = false
     open_ports    = var.open_ports
-    vpc_ports     = var.vpc_only_ports
+    vpc_only_ports     = var.vpc_only_ports
   }
 
   servers = [

--- a/terraform/azure_server/main.tf
+++ b/terraform/azure_server/main.tf
@@ -51,11 +51,11 @@ module "server" {
   name = var.name
 
   network = {
-    type          = "simple"
-    address_space = var.address_space
-    airgap        = false
-    open_ports    = var.open_ports
-    vpc_only_ports     = var.vpc_only_ports
+    type           = "simple"
+    address_space  = var.address_space
+    airgap         = false
+    open_ports     = var.open_ports
+    vpc_only_ports = var.vpc_only_ports
   }
 
   servers = [

--- a/terraform/internal/azure/images/files/windows.yaml
+++ b/terraform/internal/azure/images/files/windows.yaml
@@ -14,3 +14,11 @@ windows-2022:
   publisher: MicrosoftWindowsServer
   offer: WindowsServer
   sku: 2022-datacenter
+windows-2025:
+  publisher: MicrosoftWindowsServer
+  offer: WindowsServer
+  sku: 2025-datacenter
+windows-2025-core:
+  publisher: MicrosoftWindowsServer
+  offer: WindowsServer
+  sku: 2025-datacenter-core

--- a/terraform/internal/azure/images/main.tf
+++ b/terraform/internal/azure/images/main.tf
@@ -2,8 +2,8 @@ locals {
   linux_images   = yamldecode(file("${path.module}/files/linux.yaml"))
   windows_images = yamldecode(file("${path.module}/files/windows.yaml"))
 
-  default_linux_image   = "ubuntu-1804"
-  default_windows_image = "windows-2019"
+  default_linux_image   = "ubuntu-2204"
+  default_windows_image = "windows-2022"
 
   source_images = {
     for k, v in merge(


### PR DESCRIPTION
This PR brings in some minor changes that I've been carrying locally. 

The important change here is the correction of a typo in `terraform/azure_server/main.tf`, which was missed previously when adding support for SQL databases. 